### PR TITLE
security: baseline scan report (advisory)

### DIFF
--- a/docs/security/baseline-2026-09-09.md
+++ b/docs/security/baseline-2026-09-09.md
@@ -1,0 +1,166 @@
+# Security baseline scan — 2026-09-09 (advisory)
+
+**Status:** Advisory only. Do **not** merge this report as a production change-set, deploy, or apply application-code remediations from this document unless Security lead accepts a finding.
+
+**Repository:** `social-protocols/quality-news`  
+**Ship branch scanned:** `master` @ `01be29f3cf1a6b26f2db5ed4b08eefa36fe60fda`  
+**Application:** Public Hacker News client (Go, server-side HTML, SQLite, fly.io). Session is a client-held integer `userID` cookie used for an experimental voting/score feature.
+
+Raw scanner JSON was written **outside the git tree** (`umask 077`) to `/tmp/quality-news-security-baseline-2026-09-09/` (`secrets-history.json`, `secrets-files.json`, `code.json`, `osv.json`). Those files are not committed.
+
+---
+
+## 1. Scanner methodology
+
+| Tool | Version | Command / config | Exit | Result |
+| --- | --- | --- | --- | --- |
+| gitleaks | 8.24.2 | `gitleaks git --log-opts="--all" --redact --report-format=json` | 0 | No leaks (788 commits, ~1.67 MB) |
+| gitleaks | 8.24.2 | `gitleaks dir --redact --report-format=json` | 0 | No leaks (~340 KB working tree) |
+| semgrep | 1.176.1 | `semgrep scan --config=p/default --metrics=off --json` | 0 | 23 findings, 0 parse errors; 178 rules, 91 git-tracked targets, ~100% parse |
+| osv-scanner | 2.5.1 (osv-scalibr 0.5.2) | `osv-scanner scan source --recursive --format json --output-file` | 1 (vulns found) | 1 lockfile (`go.mod`), 54 packages resolved, **10 packages with known vulns** |
+
+osv-scanner v2.5.1 uses `--output-file` ( `--output` is deprecated). Source walk: 26 dirs, 166 inodes, extract on `go.mod` only.
+
+No scanner ignore/config was added. Semgrep default rules already emit several low-confidence hits that are documented below as likely false positives; a repo-wide ignore would hide real neighbors.
+
+---
+
+## 2. Coverage and gaps
+
+**In scope for scanners**
+
+- Go sources (31 `*.go`), GitHub Actions YAML (3 workflows + Mergify), Dockerfile, bash scripts, `go.mod` / `go.sum`.
+- Semgrep language mix on this tree: Go (84 rules / 31 files), YAML (35 / 5), bash (4 / 3), Dockerfile (6 / 1), JSON (4 / 1), multilang (49 / 91).
+- gitleaks: full git history (`--all`) and current directory (respects `.gitignore`; `.envrc.local` is ignored and was not present).
+
+**Gaps (verify / do not assume clean)**
+
+| Gap | Why it matters |
+| --- | --- |
+| **Go HTML/JS templates (`templates/*.tmpl`, 18 files)** | Semgrep `p/default` does not treat `.tmpl` as HTML/JS. XSS/DOM sinks in `index.html.tmpl`, `score.html.tmpl`, `vote.js.tmpl` were reviewed by hand only. |
+| **SQL files (12 under `sql/` plus ad-hoc `.sql`)** | Not covered by Go SQLi rules. App SQL is mostly in `.go` string literals (partially scanned). |
+| **No JS lockfile** | Front-end JS is inline templates + GoatCounter CDN (`//gc.zgo.at/count.js`). osv-scanner has nothing to resolve for that third-party script. |
+| **Nix/devbox lock not scanned** | `devbox.lock` / `devbox.json` (`go@latest`, `gcc@latest`, etc.) are not a supported osv source extract. Dev-toolchain supply chain is uncovered. |
+| **Container / OS packages** | osv source scan did not inspect `golang:1.23-bookworm` / `debian:bookworm-slim` or `libsqlite3-0`. Image CVE scan was not run. |
+| **Fly / R2 / GitHub secrets** | Not in git. gitleaks cannot see `FLY_API_TOKEN`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` at rest in fly.io or Actions. |
+| **Static binaries / images** | 16 PNGs, SVG, ICO, webmanifest — not secret-scanned as decoded assets. |
+| **Call-graph / reachability** | osv-scanner was not run with `--call-analysis=go`. Many `golang.org/x/crypto` hits are SSH-stack; this app does not import `golang.org/x/crypto` directly. |
+| **Runtime / production** | No production access. Authz, CSRF, and metrics exposure are inferred from source + `fly.toml` only. |
+
+`.gitignore` excludes `/data`, `/.envrc.local`, `personal-notes.md`, `working-query.sql`. Those paths were not in the working tree.
+
+---
+
+## 3. Findings register
+
+Severity is an analyst rating for **this** app (public read-mostly HN viewer with a lightweight vote experiment), not CVSS. Confidence: High / Medium / Low. Disposition: **Open** unless marked likely false positive.
+
+### High
+
+| ID | Source | Location | Finding | Confidence | Notes |
+| --- | --- | --- | --- | --- | --- |
+| **QN-001** | Manual (authz) | `auth.go`, `httpserver.go` `/login`, `score-page.go` | **Session is an unsigned, client-controlled integer.** `userID` cookie has no MAC/signature. `GET /login` binds `UserID` from the query string via `gorilla/schema` and calls `setUserIDCookie`. `GET /score` accepts `UserID` and, if present, **ignores the cookie** and renders that user's positions. Combined: anyone can assume any numeric identity, vote as that identity (`POST /vote` trusts the cookie), and read another user's vote history. Special-case block is only `userID < 100` on vote insert and `userID == 0` on login. | High | Design may be intentional for a demo, but it is not an authorization boundary. Cookie flags (`HttpOnly`, `Secure`, `SameSite=Lax`) do not stop the client from choosing the value. |
+| **QN-002** | Manual (authz / CSRF) | `auth.go` `loginHandler` | **Login is a state-changing GET** that always applies a provided `UserID`, including when a cookie already exists. A third-party page can point a victim at `/login?UserID=…` and swap their session (SameSite=Lax is sent on top-level GET). | High | Pair with QN-001: attacker does not need to steal a cookie. |
+| **QN-003** | osv-scanner | `go.mod` `github.com/gorilla/schema@1.2.0` | **CVE-2024-37298 / GO-2024-2958 / GHSA-3669-72x9-r9p3** — sparse-slice deserialization can exhaust memory. Fixed in **1.4.1**. This decoder runs on **every routed GET** (`middleware.go` `unmarshalRouterRequest`). | High | Direct dependency on the public request path. |
+| **QN-004** | semgrep + manual | `.github/workflows/deploy.yml` | **Deploy supply chain.** `superfly/flyctl-actions/setup-flyctl@master` is a **moving branch**. `actions/checkout@v3` is a mutable tag. Workflow-level `env.FLY_API_TOKEN` (semgrep `gha-workflow-env-secret`) is available to every step. Deploy runs `flyctl deploy` on **every push to `master`** with no environment protection visible in-repo, no build provenance, and no pinned flyctl version. | High | `gha-workflow-env-secret` is less severe here than on `pull_request` workflows (this file is push-to-master only). The `@master` flyctl action remains the sharp edge. |
+| **QN-005** | Manual (CI) | `.mergify.yml` | **Dependency PRs auto-merge** when labeled `dependencies`, with **empty `merge_conditions`**. A compromised or mistaken Dependabot/Renovate PR can ship to `master` and trigger QN-004 deploy. | High | Other queues require review-thread cleanliness; this one does not. |
+
+### Medium
+
+| ID | Source | Location | Finding | Confidence | Notes |
+| --- | --- | --- | --- | --- | --- |
+| **QN-006** | semgrep + manual | `.github/workflows/format.yml` | Comment-triggered `/format` job checks out a PR, runs `gofmt`, **commits, and pushes** using `GITHUB_TOKEN`. Actions pinned to mutable tags, including third-party `khan/pull-request-comment-trigger@v1.1.0`. Triggered on `issue_comment` / PR opened; default `GITHUB_TOKEN` permissions are not declared (`permissions:` absent → repo default, often write). | Medium | Fork PRs typically cannot be pushed with the default token; same-repo branches can. Still a write-capable automation surface. |
+| **QN-007** | semgrep | `Dockerfile:44` `CMD ["./news"]` | **Image runs as root** (rule `dockerfile.security.missing-user`, severity ERROR). Runtime stage is `debian:bookworm-slim` with no `USER`. | Medium | Worsens impact of RCE in the Go process (SQLite + R2 credentials in env). |
+| **QN-008** | Manual | `prometheus.go`, `fly.toml` `[metrics]` | **`/metrics` has no auth.** `metrics.WritePrometheus(w, true)` on `:9091`. `LISTEN_ADDRESS` empty in `fly.toml` → process listens on all interfaces. Fly scrapes this port; whether it is reachable beyond Fly’s metrics network was **not verified** (no prod access). | Medium | Process/runtime metrics only; still useful for fingerprinting and as a foothold if the 6PN/internal network is broader than assumed. |
+| **QN-009** | Manual | HTTP handlers / templates | **No security response headers** (`Content-Security-Policy`, `X-Frame-Options` / `frame-ancestors`, `X-Content-Type-Options`, `Referrer-Policy`). Third-party script `//gc.zgo.at/count.js` loads on every HTML page. | Medium | Raises impact of any XSS (QN-010). |
+| **QN-010** | semgrep (low) + manual | `statspage.go` `template.JS`; `templates/storyDetails.html.tmpl` `href="{{.URL}}"`; `templates/vote.js.tmpl` `.innerHTML` | **External and stored content is rendered into HTML/JS.** Story title/URL/author come from HN scrape + API. `html/template` contextual escaping applies to `{{.URL}}` / `{{.Title}}` (good). `template.JS` wraps `json.Marshal` of plot series (numeric) **and** of **archive JSON loaded from R2** (`statspage.go`). `vote.js.tmpl` assigns `innerHTML` from numeric `toFixed` / score strings (low XSS if types stay numeric). Score plot embeds **story titles** in `ScorePlotData` (`score-page.go`) rendered as `{{.ScorePlotData}}` inside a `<script>` (engine JS-escapes `any`; titles are still untrusted HN text). | Medium | Residual XSS if archive objects in R2 are attacker-writable, or if a future change stops using `html/template` escaping. Semgrep `unsafe-template-type` is LOW confidence and partly noisy. |
+| **QN-011** | osv-scanner | `golang.org/x/net@0.30.0` (indirect; HTML stack used by Colly/goquery) | Multiple HTML-parser issues including **CVE-2026-25680** (DoS on arbitrary HTML), **CVE-2026-27136** (duplicate attributes / XSS in `x/net/html`), quadratic/infinite parse (**CVE-2025-47911**, **CVE-2025-58190**). Fixed versions cluster around **0.55.0+** (some earlier). Crawler fetches `news.ycombinator.com` HTML every minute. | Medium | App extracts fields rather than reflecting raw HN HTML; XSS via `x/net/html` is less likely than **crawler DoS**. Source is “trusted” but not a security boundary. |
+| **QN-012** | osv-scanner | `github.com/hashicorp/go-retryablehttp@0.7.1` | **CVE-2024-6104** — basic-auth credentials can leak to logs. Fixed in **0.7.7**. Used as the HN HTTP client (`app.go`). | Medium | App does not appear to set basic auth on that client (R2 uses MinIO static V4 keys, not this client). Residual if URL userinfo is ever used. Default `LOG_LEVEL=DEBUG` (`fly.toml`, `logger.go`) increases log sensitivity. |
+
+### Low / informational
+
+| ID | Source | Location | Finding | Confidence | Notes |
+| --- | --- | --- | --- | --- | --- |
+| **QN-013** | semgrep | `auth.go` `math/rand.Int63()` | Non-crypto RNG for new user IDs. | Medium (rule) / **Low impact** | IDs are not a secret once QN-001 exists. Still wrong if IDs are ever treated as unguessable. |
+| **QN-014** | semgrep | `.github/workflows/{build,format,deploy}.yml` | **11× mutable Action tags** (`checkout@v3`, `setup-go@v3`, `golangci-lint-action@v3`, `khan/pull-request-comment-trigger@v1.1.0`). | High | Standard supply-chain hygiene; deploy `@master` is already QN-004. |
+| **QN-015** | Manual | `fly.toml`, `.envrc` | Cloudflare R2 **account subdomain** (`….r2.cloudflarestorage.com`) and bucket names committed. Not credentials. `.envrc.local.example` uses placeholder keys; `.envrc.local` is gitignored. | High (info) | Useful for targeting; rotate is N/A. |
+| **QN-016** | osv-scanner | `github.com/antchfx/xmlquery@1.2.4`, `xpath@1.1.8` | DoS / infinite-loop CVEs (CVE-2020-25614, CVE-2026-32287). Transitive via Colly. Fix xmlquery **1.3.1**, xpath **1.3.6**. | Medium | Same crawl-DoS theme as QN-011. |
+| **QN-017** | osv-scanner | `google.golang.org/protobuf@1.24.0` | CVE-2024-24786 protojson infinite loop. Fix **1.33.0**. Indirect (old `google.golang.org/appengine` via Colly). | Low | No evidence the HTTP app unmarshals protobuf JSON from clients. |
+| **QN-018** | osv-scanner | `golang.org/x/crypto@0.28.0` | Large SSH/agent advisory set (many 2025–2026 CVEs). App code does **not** import `golang.org/x/crypto`. Likely pulled by `minio-go`. | Low | Treat as **unverified reachability**. Still overdue for `go get -u golang.org/x/crypto`. |
+| **QN-019** | osv-scanner | `klauspost/compress@1.17.11`, `x/sys@0.26.0`, `x/text@0.19.0` | OOB read in `compress/s2` (fix 1.18.7); Windows-only `x/sys` overflow; `x/text` infinite loop (fix 0.39.0). | Low | Linux/Fly deploy: `x/sys/windows` not applicable. compress/s2 only if that codec is used (MinIO path). |
+| **QN-020** | Manual | `main.go` recovery mux | `RECOVERY_MODE=true` serves an unauthenticated “ok” HTTP server and disables DB workers. Operator-controlled env, not attacker-set. | Info | Documented operational mode; no in-repo auth on that mux. |
+| **QN-021** | Manual | `vote.go` | Vote POST has no CSRF token. Mitigated by `SameSite=Lax` + JSON body (classic form CSRF unlikely). Cross-origin `fetch` with `credentials: 'include'` would require CORS; no CORS middleware observed. | Low | Secondary to QN-001/002. |
+
+### Likely false positives (kept for scanner audit trail)
+
+| ID | Source | Why dismissed / downgraded |
+| --- | --- | --- |
+| **QN-FP-1** | semgrep `string-formatted-query` `database.go:49,208`, `archive.go:649` | `ATTACH` / `VACUUM INTO` interpolate **operator-controlled** `SQLITE_DATA_DIR` + constant filenames, not request data. Front-page ranking SQL (`frontpage.go`) interpolates **typed floats/ints** (`%f`/`%d`) and `where`/`orderBy` derived from **hardcoded route names**, not raw query strings. |
+| **QN-FP-2** | semgrep `open-redirect` `canonicaldomain.go:24` | Redirect target host is taken from a **fixed allowlist** (`social-protocols-news.fly.dev` → `news.social-protocols.org`). `r.RequestURI` is appended as a path. Not a classic open redirect. Host header must already match the non-canonical map. |
+| **QN-FP-3** | semgrep `no-direct-write-to-responsewriter` `vote.go:209` | Writes `application/json` from `json.Marshal`, not HTML. |
+| **QN-FP-4** | semgrep `unsafe-template-type` (partial) | `template.JS(string(json.Marshal(...)))` of numeric plot arrays is the usual Go pattern; risk is QN-010 (archive / title data), not “constant HTML”. |
+
+---
+
+## 4. Threat questions
+
+### Secrets
+
+- **Git history and working tree:** gitleaks found **no** live secrets (redacted reports empty).
+- **In-repo identifiers:** R2 endpoint account hash and bucket names (`fly.toml`, `.envrc`). Placeholder R2 keys only in `.envrc.local.example`.
+- **Intended secret handling:** R2 access/secret keys and `FLY_API_TOKEN` are environment / GitHub Actions secrets. Deploy workflow copies the Fly token into job env (QN-004).
+- **Log leakage:** `LOG_LEVEL=DEBUG` in production `fly.toml`; retryablehttp CVE (QN-012) is relevant if credentials ever appear in URLs.
+- **Recommendation (advisory):** confirm Fly secrets are not also stored in git history on **other** remotes; rotate Fly and R2 credentials if any past leak is suspected; keep `.envrc.local` uncommitted.
+
+### Authorization
+
+- **There is no authenticated user in the usual sense.** Identity is “whatever integer the client presents” (QN-001, QN-002).
+- Vote write path checks cookie presence and `userID >= 100` only.
+- Score page is an **IDOR**: `?UserID=` selects another user’s positions without proving control of that cookie.
+- Health endpoints (`/health`, `/crawl-health`) are unauthenticated by design.
+- Canonical-host middleware **does** reject unknown `Host` values (403). That is host-routing hardening, not authz.
+- Recovery mode and metrics (QN-008, QN-020) have no application auth.
+
+### Unsafe rendering of external content
+
+- Primary untrusted inputs: HN story **title, URL, author, domain** (scraper + API) and **user-controlled query params** (ranking knobs, `UserID`, `ScoringFormula` — formula is a closed switch in `scoring-formula.go`, unused strings score `0`).
+- Templates use `html/template` (contextual escaping). Story links use `href="{{.URL}}"`.
+- Deliberate escape bypass: `template.JS` for chart JSON; archive path deserializes **R2 objects** then re-injects as JS (QN-010).
+- Client `innerHTML` in `vote.js.tmpl` is currently numeric. GoatCounter script is a third-party XSS/supply-chain dependency (QN-009).
+- Semgrep did **not** cover `.tmpl` files; this section is manual.
+
+### CI / deploy supply chain
+
+- **Build:** `actions/checkout@v3` + `actions/setup-go@v3` on PRs; golangci-lint **v1.50.1** via mutable action tag. `permissions: contents: read` on `build.yml` only.
+- **Deploy:** push to `master` → unpinned `flyctl` from `@master` → production Fly app `social-protocols-news` (QN-004).
+- **Merge automation:** Mergify queues all PRs; **dependencies** label auto-squash-merges (QN-005).
+- **Write automation:** `/format` comment workflow can push commits (QN-006).
+- **Dockerfile:** multi-stage, `go build` in-tree, runs as root (QN-007). Base images unpinned beyond distro tags (`bookworm`).
+- **No** in-repo SBOM, pinned Action SHAs, deploy approvals, or scanner gates in CI.
+
+### Dependency vulnerabilities
+
+osv-scanner reported **10 vulnerable Go modules** (direct + indirect) from `go.mod`. Highest **reachable** concerns:
+
+1. **`gorilla/schema@1.2.0`** — request-path DoS (QN-003). Direct. Bump to **≥ 1.4.1**.
+2. **`golang.org/x/net@0.30.0`** — HTML parse DoS/XSS in crawl stack (QN-011). Bump toward **≥ 0.56.0** (covers the 2026 cluster).
+3. **Colly HTML/XML stack** — `xmlquery` / `xpath` (QN-016); Colly itself is **v2.1.0** (2019-era).
+4. **`go-retryablehttp@0.7.1`** — log leak (QN-012). Direct. Bump to **≥ 0.7.7**.
+5. **`golang.org/x/crypto@0.28.0`** — many SSH CVEs; **reachability unverified** (QN-018). Still bump with `x/net` / `x/text`.
+6. **`google.golang.org/protobuf@1.24.0`** — likely crawl-transitive only (QN-017).
+
+`go.sum` is present (227 lines) and was the checksum companion; osv-scanner v2 listed the extract source as `go.mod` type `lockfile` (54 packages). That is expected for Go; it is **not** a missing lockfile. It is **not** a container SBOM.
+
+---
+
+## 5. Suggested priority for Security lead (not a patch plan)
+
+This PR contains **only this register**. Suggested order if work is later authorized:
+
+1. Treat session/IDOR (QN-001/002) as a **product decision**: either document “no security boundary / votes are anonymous toys,” or replace the cookie with an unguessable, server-side session (and stop accepting `UserID` from the query).
+2. Pin GitHub Actions to SHAs; stop `flyctl-actions@master`; require a human gate before `master` deploy; add merge conditions on the `dependencies` Mergify queue (QN-004/005/006/014).
+3. Bump **direct** vulnerable modules on the request and HTTP-client path: `gorilla/schema`, `go-retryablehttp`, then `golang.org/x/net` / Colly stack (QN-003/011/012/016).
+4. Run container as non-root; decide whether `:9091/metrics` must be network-isolated (QN-007/008).
+5. Add CSP (at least restrict `script-src`) and keep archive JSON on a `json.Marshal` → `template.JS` path that never includes raw HTML (QN-009/010).
+
+No production access, no spend, and no application-code changes were made for this baseline.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Advisory only — do not merge as a production change, deploy, or apply application-code fixes from this PR unless Security lead explicitly accepts a finding.**

This PR adds a single findings register from a defensive scanner baseline of `master` @ `01be29f3cf1a6b26f2db5ed4b08eefa36fe60fda`.

## What is in this PR
- `docs/security/baseline-2026-09-09.md` only

## What is not in this PR
- No application, CI, Dockerfile, or ignore/config changes
- Raw scanner JSON was written outside the git tree (`umask 077`) and is not committed

## Scanners
| Tool | Result |
| --- | --- |
| gitleaks 8.24.2 (git `--all` + dir) | No leaks |
| semgrep 1.176.1 `p/default` | 23 findings (several likely FPs documented) |
| osv-scanner 2.5.1 source `--recursive` | 10 Go modules with known vulns (`go.mod`) |

## For Security lead
See the register for full IDs. Highest-priority themes: unsigned/client-chosen `userID` session + IDOR; CI/deploy supply chain (`flyctl@master`, Mergify auto-merge on `dependencies`); `gorilla/schema@1.2.0` request-path DoS CVE; crawl-stack `x/net`/Colly parser CVEs; coverage gaps on `.tmpl` templates, container OS packages, and Fly/R2 secrets at rest.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7f2a88f-a6cc-4610-b06c-934734d4ff92?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7f2a88f-a6cc-4610-b06c-934734d4ff92&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

